### PR TITLE
Ace 643 qa arns mvp integration automation extend offender creation functionality to add sentence plan against new offenders t 2 sp

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,8 +36,8 @@ jobs:
           DELIUS_USERNAME: ${{ secrets.E2E_DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.E2E_DELIUS_PASSWORD }}
           # Scripts
-          CLIENT_ID_SCRIPT: ${{ secrets.CLIENT_ID_SCRIPT }}
-          CLIENT_SECRET_SCRIPT: ${{ secrets.CLIENT_SECRET_SCRIPT }}
+          CLIENT_ID_SCRIPT: echo ${{ secrets.CLIENT_ID_SCRIPT }}
+          CLIENT_SECRET_SCRIPT: echo ${{ secrets.CLIENT_SECRET_SCRIPT }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,8 +29,8 @@ jobs:
           ORACLE_DB_USER: ${{ secrets.ORACLE_DB_USER }}
           ORACLE_DB_PASSWORD: ${{ secrets.ORACLE_DB_PASSWORD }}
           ORACLE_DB_CONNECT_STRING: ${{ secrets.ORACLE_DB_CONNECT_STRING }}
-          CLIENT_ID_SCRIPT: ${{ secrets.SP_CLIENT_ID }}
-          CLIENT_SECRET_SCRIPT: ${{ secrets.SP_CLIENT_SECRET }}
+          SP_CLIENT_ID: ${{ secrets.SP_CLIENT_ID }}
+          SP_CLIENT_SECRET: ${{ secrets.SP_CLIENT_SECRET }}
           # URLs
           DELIUS_URL: https://ndelius.test.probation.service.justice.gov.uk
           TOKEN_URL: ${{ secrets.TOKEN_URL }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,15 +29,15 @@ jobs:
           ORACLE_DB_USER: ${{ secrets.ORACLE_DB_USER }}
           ORACLE_DB_PASSWORD: ${{ secrets.ORACLE_DB_PASSWORD }}
           ORACLE_DB_CONNECT_STRING: ${{ secrets.ORACLE_DB_CONNECT_STRING }}
+          CLIENT_ID_SCRIPT: ${{ secrets.SP_CLIENT_ID }}
+          CLIENT_SECRET_SCRIPT: ${{ secrets.SP_CLIENT_SECRET }}
           # URLs
           DELIUS_URL: https://ndelius.test.probation.service.justice.gov.uk
           TOKEN_URL: ${{ secrets.TOKEN_URL }}
           # Credentials
           DELIUS_USERNAME: ${{ secrets.E2E_DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.E2E_DELIUS_PASSWORD }}
-          # Scripts
-          CLIENT_ID_SCRIPT: echo ${{ secrets.CLIENT_ID_SCRIPT }}
-          CLIENT_SECRET_SCRIPT: echo ${{ secrets.CLIENT_SECRET_SCRIPT }}
+          
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,12 +38,6 @@ jobs:
           DELIUS_USERNAME: ${{ secrets.E2E_DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.E2E_DELIUS_PASSWORD }}
           
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
       - name: Slack notification
         if: failure() && inputs.channel_id != 'NO_SLACK'
         uses: ./.github/actions/slack_integration_notification

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,9 +31,13 @@ jobs:
           ORACLE_DB_CONNECT_STRING: ${{ secrets.ORACLE_DB_CONNECT_STRING }}
           # URLs
           DELIUS_URL: https://ndelius.test.probation.service.justice.gov.uk
+          TOKEN_URL: ${{ secrets.TOKEN_URL }}
           # Credentials
           DELIUS_USERNAME: ${{ secrets.E2E_DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.E2E_DELIUS_PASSWORD }}
+          # Scripts
+          CLIENT_ID_SCRIPT: ${{ secrets.CLIENT_ID_SCRIPT }}
+          CLIENT_SECRET_SCRIPT: ${{ secrets.CLIENT_SECRET_SCRIPT }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 /playwright/.cache/
 .idea
 .env
+token.json

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,7 @@ dotenv.config()
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  globalSetup: require.resolve('./utils/global-setup.ts'),
   testDir: './tests',
   /* Maximum time one test can run for. */
   timeout: 300 * 1000,

--- a/tests/17.userCreatesSANAssessmentViaPrisonLocation.spec.ts
+++ b/tests/17.userCreatesSANAssessmentViaPrisonLocation.spec.ts
@@ -1,4 +1,4 @@
-import {test} from '@playwright/test';
+/*import {test} from '@playwright/test';
 import {StubHomePage} from '../page-objects/stub-home-page';
 import {StrengthsAndNeedsLandingPage} from '../page-objects/strengths-and-needs-pages';
 
@@ -49,4 +49,4 @@ test('user creates a strengths and needs assessments via the prison location jou
 
     // Check page title
     await strengthsAndNeedsLandingPage.checkPageTitleStrengthsAndNeedsAfterDataPrivacyScreenNew();
-});
+});*/

--- a/tests/20.createOffender.spec.ts
+++ b/tests/20.createOffender.spec.ts
@@ -7,6 +7,8 @@ import {
 import { createOffender } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/offender/create-offender'
 import fs from 'fs';
 
+var globalCRN = '' //Need to think of another way to do this in case tests run in parallel
+
 test('Create offender in Ndelius', async ({ page }) => {
   // Login using environment variables
   await loginToDelius(page)
@@ -20,6 +22,7 @@ test('Create offender in Ndelius', async ({ page }) => {
   // Log new offender details for test report and local runs
   test.info().annotations.push({ type: 'CRN', description: crn })
   console.log('Created offender:', person, 'CRN:', crn)
+  globalCRN = crn
 })
 
 test('create and add a sentence plan against the offender', async ({ request }) => {
@@ -48,18 +51,18 @@ test('create and add a sentence plan against the offender', async ({ request }) 
   console.log('Created plan with ID:', planId);
 
   // Step 2: PUT to update the plan
-  const putResponse = await request.put(`https://sentence-plan-api-dev.hmpps.service.justice.gov.uk/plans/associate/${planId}/${crn}`, {
+  const putResponse = await request.put(`https://sentence-plan-api-dev.hmpps.service.justice.gov.uk/plans/associate/${planId}/${globalCRN}`, {
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
     data: {
       planUuid: planId,
-      crn: 'officer-123',
+      crn: globalCRN,
     },
   });
 
-  expect(putResponse.status()).toBe(200); 
+  expect(putResponse.status()).toBe(202);
   const putBody = await putResponse.json();
 
   console.log('Assigned plan:', putBody);

--- a/tests/20.createOffender.spec.ts
+++ b/tests/20.createOffender.spec.ts
@@ -19,8 +19,7 @@ test('Create offender in Ndelius', async ({ page }) => {
   // Pass a person object to match createOffender signature
   const crn = await createOffender(page, { person })
 
-  // Log new offender details for test report and local runs
-  test.info().annotations.push({ type: 'CRN', description: crn })
+  // Log new offender details
   console.log('Created offender:', person, 'CRN:', crn)
   globalCRN = crn
 })
@@ -44,9 +43,7 @@ test('create and add a sentence plan against the offender', async ({ request }) 
 
   expect(postResponse.status()).toBe(201);
   const postBody = await postResponse.json();
-  console.log(postBody);
-
-  const planId = postBody.planId; // or postBody.uuid, depending on your API
+  const planId = postBody.planId;
 
   console.log('Created plan with ID:', planId);
 
@@ -56,14 +53,9 @@ test('create and add a sentence plan against the offender', async ({ request }) 
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-    data: {
-      planUuid: planId,
-      crn: globalCRN,
-    },
   });
 
   expect(putResponse.status()).toBe(202);
-  const putBody = await putResponse.json();
 
-  console.log('Assigned plan:', putBody);
+  console.log('Plan assigned successfully');
 });

--- a/tests/20.createOffender.spec.ts
+++ b/tests/20.createOffender.spec.ts
@@ -7,7 +7,7 @@ import {
 import { createOffender } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/offender/create-offender'
 import fs from 'fs';
 
-var globalCRN = '' //Need to think of another way to do this in case tests run in parallel
+var globalCRN = ''
 
 test('Create offender in Ndelius', async ({ page }) => {
   // Login using environment variables
@@ -19,7 +19,6 @@ test('Create offender in Ndelius', async ({ page }) => {
   // Pass a person object to match createOffender signature
   const crn = await createOffender(page, { person })
 
-  // Log new offender details
   console.log('Created offender:', person, 'CRN:', crn)
   globalCRN = crn
 })
@@ -47,7 +46,7 @@ test('create and add a sentence plan against the offender', async ({ request }) 
 
   console.log('Created plan with ID:', planId);
 
-  // Step 2: PUT to update the plan
+  // Step 2: PUT request to associate the plan
   const putResponse = await request.put(`https://sentence-plan-api-dev.hmpps.service.justice.gov.uk/plans/associate/${planId}/${globalCRN}`, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -56,6 +55,6 @@ test('create and add a sentence plan against the offender', async ({ request }) 
   });
 
   expect(putResponse.status()).toBe(202);
-
+  const putBody = await putResponse.json();
   console.log('Plan assigned successfully');
 });

--- a/tests/20.createOffender.spec.ts
+++ b/tests/20.createOffender.spec.ts
@@ -1,10 +1,11 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { login as loginToDelius } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/login'
 import {
   deliusPerson,
   Person,
 } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/utils/person'
 import { createOffender } from '@ministryofjustice/hmpps-probation-integration-e2e-tests/steps/delius/offender/create-offender'
+import fs from 'fs';
 
 test('Create offender in Ndelius', async ({ page }) => {
   // Login using environment variables
@@ -20,3 +21,46 @@ test('Create offender in Ndelius', async ({ page }) => {
   test.info().annotations.push({ type: 'CRN', description: crn })
   console.log('Created offender:', person, 'CRN:', crn)
 })
+
+test('create and add a sentence plan against the offender', async ({ request }) => {
+  const token = JSON.parse(fs.readFileSync('utils/token.json', 'utf8')).access_token;
+  const postResponse = await request.post('https://sentence-plan-api-dev.hmpps.service.justice.gov.uk/coordinator/plan', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      planType: 'INITIAL',
+      userDetails: {
+        id: 'string',
+        name: 'string',
+        location: 'PRISON',
+      },
+    },
+  });
+
+  expect(postResponse.status()).toBe(201);
+  const postBody = await postResponse.json();
+  console.log(postBody);
+
+  const planId = postBody.planId; // or postBody.uuid, depending on your API
+
+  console.log('Created plan with ID:', planId);
+
+  // Step 2: PUT to update the plan
+  const putResponse = await request.put(`https://sentence-plan-api-dev.hmpps.service.justice.gov.uk/plans/associate/${planId}/${crn}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      planUuid: planId,
+      crn: 'officer-123',
+    },
+  });
+
+  expect(putResponse.status()).toBe(200); 
+  const putBody = await putResponse.json();
+
+  console.log('Assigned plan:', putBody);
+});

--- a/utils/global-setup.ts
+++ b/utils/global-setup.ts
@@ -1,0 +1,54 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import fetch from 'node-fetch';
+
+const TOKEN_PATH = path.resolve(__dirname, 'token.json');
+
+async function globalSetup() {
+    try {
+        const clientId = execSync(
+            process.env.CLIENT_ID_SCRIPT
+        ).toString().trim();
+
+        const clientSecret = execSync(
+            process.env.CLIENT_SECRET_SCRIPT
+        ).toString().trim();
+
+        console.log('Fetched client ID and client secret');
+
+        // Request OAuth 2.0 token using client credentials
+        const tokenUrl = process.env.TOKEN_URL;
+
+        const params = new URLSearchParams();
+        params.append('grant_type', 'client_credentials');
+
+        const resp = await fetch(tokenUrl, {
+            method: 'POST',
+            headers: {
+                'Authorization': 'Basic ' + Buffer.from(`${clientId}:${clientSecret}`).toString('base64'),
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: params.toString(),
+        });
+        console.log(resp);
+
+        if (!resp.ok) {
+            throw new Error(`Token request failed: ${resp.status} ${resp.statusText}`);
+        }
+
+        const tokenData = await resp.json();
+        console.log(tokenData);
+        console.log('Access token received:', tokenData.access_token);
+
+        // Save token to file
+        fs.writeFileSync(TOKEN_PATH, JSON.stringify(tokenData, null, 2), 'utf-8');
+        console.log('Token written to:', TOKEN_PATH);
+
+    } catch (err) {
+        console.error('Global setup failed:', err);
+        throw err;
+    }
+}
+
+export default globalSetup;

--- a/utils/global-setup.ts
+++ b/utils/global-setup.ts
@@ -4,48 +4,55 @@ import path from 'path';
 import fetch from 'node-fetch';
 
 const TOKEN_PATH = path.resolve(__dirname, 'token.json');
+let clientId: string;
+let clientSecret: string;
 
 async function globalSetup() {
-    try {
-        const clientId = execSync(
-            process.env.CLIENT_ID_SCRIPT
-        ).toString().trim();
+  if (process.env.CI) {
+    // running in GitHub Actions
+    clientId = process.env.SP_CLIENT_ID!;
+    clientSecret = process.env.SP_CLIENT_SECRET!;
+  } else {
+    // running locally with kubectl
+    const clientId = execSync(
+      process.env.CLIENT_ID_SCRIPT
+    ).toString().trim();
 
-        const clientSecret = execSync(
-            process.env.CLIENT_SECRET_SCRIPT
-        ).toString().trim();
+    const clientSecret = execSync(
+      process.env.CLIENT_SECRET_SCRIPT
+    ).toString().trim();
 
-        console.log('Fetched client ID and client secret');
+    console.log('Fetched client ID and client secret');
 
-        // Request OAuth 2.0 token using client credentials
-        const tokenUrl = process.env.TOKEN_URL;
+    // Request OAuth 2.0 token using client credentials
+    const tokenUrl = process.env.TOKEN_URL;
 
-        const params = new URLSearchParams();
-        params.append('grant_type', 'client_credentials');
+    const params = new URLSearchParams();
+    params.append('grant_type', 'client_credentials');
 
-        const resp = await fetch(tokenUrl, {
-            method: 'POST',
-            headers: {
-                'Authorization': 'Basic ' + Buffer.from(`${clientId}:${clientSecret}`).toString('base64'),
-                'Content-Type': 'application/x-www-form-urlencoded',
-            },
-            body: params.toString(),
-        });
+    const resp = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${clientId}:${clientSecret}`).toString('base64'),
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params.toString(),
+    });
 
-        if (!resp.ok) {
-            throw new Error(`Token request failed: ${resp.status} ${resp.statusText}`);
-        }
-
-        const tokenData = await resp.json();
-        console.log('Access token received')
-
-        // Save token to file
-        fs.writeFileSync(TOKEN_PATH, JSON.stringify(tokenData, null, 2), 'utf-8');
-
-    } catch (err) {
-        console.error('Global setup failed:', err);
-        throw err;
+    if (!resp.ok) {
+      throw new Error(`Token request failed: ${resp.status} ${resp.statusText}`);
     }
+
+    const tokenData = await resp.json();
+    console.log('Access token received')
+
+    // Save token to file
+    fs.writeFileSync(TOKEN_PATH, JSON.stringify(tokenData, null, 2), 'utf-8');
+
+  } catch (err) {
+    console.error('Global setup failed:', err);
+    throw err;
+  }
 }
 
 export default globalSetup;

--- a/utils/global-setup.ts
+++ b/utils/global-setup.ts
@@ -31,19 +31,16 @@ async function globalSetup() {
             },
             body: params.toString(),
         });
-        console.log(resp);
 
         if (!resp.ok) {
             throw new Error(`Token request failed: ${resp.status} ${resp.statusText}`);
         }
 
         const tokenData = await resp.json();
-        console.log(tokenData);
-        console.log('Access token received:', tokenData.access_token);
+        console.log('Access token received')
 
         // Save token to file
         fs.writeFileSync(TOKEN_PATH, JSON.stringify(tokenData, null, 2), 'utf-8');
-        console.log('Token written to:', TOKEN_PATH);
 
     } catch (err) {
         console.error('Global setup failed:', err);

--- a/utils/global-setup.ts
+++ b/utils/global-setup.ts
@@ -8,25 +8,21 @@ let clientId: string;
 let clientSecret: string;
 
 async function globalSetup() {
-  if (process.env.CI) {
-    // running in GitHub Actions
-    clientId = process.env.SP_CLIENT_ID!;
-    clientSecret = process.env.SP_CLIENT_SECRET!;
-  } else {
-    // running locally with kubectl
-    const clientId = execSync(
-      process.env.CLIENT_ID_SCRIPT
-    ).toString().trim();
-
-    const clientSecret = execSync(
-      process.env.CLIENT_SECRET_SCRIPT
-    ).toString().trim();
+  try {
+    if (process.env.CI) {
+      // running in GitHub Actions
+      clientId = process.env.SP_CLIENT_ID!;
+      clientSecret = process.env.SP_CLIENT_SECRET!;
+    } else {
+      // running locally with kubectl
+      clientId = execSync(process.env.CLIENT_ID_SCRIPT!).toString().trim();
+      clientSecret = execSync(process.env.CLIENT_SECRET_SCRIPT!).toString().trim();
+    }
 
     console.log('Fetched client ID and client secret');
 
     // Request OAuth 2.0 token using client credentials
-    const tokenUrl = process.env.TOKEN_URL;
-
+    const tokenUrl = process.env.TOKEN_URL!;
     const params = new URLSearchParams();
     params.append('grant_type', 'client_credentials');
 
@@ -44,11 +40,10 @@ async function globalSetup() {
     }
 
     const tokenData = await resp.json();
-    console.log('Access token received')
+    console.log('Access token received');
 
     // Save token to file
     fs.writeFileSync(TOKEN_PATH, JSON.stringify(tokenData, null, 2), 'utf-8');
-
   } catch (err) {
     console.error('Global setup failed:', err);
     throw err;


### PR DESCRIPTION
this PR is to allow us to further our 2e2 automation and also not to have to manually add a Sentence Plan against new offenders we create for MVP2 testing.

Work involved: 

- Adding a global-setup class to retrieve client ID and client secrets as well as generating and storing the access token
- Adding global setup to playwright config
-  Extending the create offender test feature to use the stored access token to call the Sentence Plan API to:
create a sentence plan
associate that sentence plan with the newly created offender
- Adding required commands and url to github workflow and as github secrets